### PR TITLE
bug: add VITE_NLP_WORD_TAGGER_MAX_INPUT to build arg for release #61

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          build-args: |
+                      VITE_NLP_WORD_TAGGER_MAX_INPUT=600


### PR DESCRIPTION
Close #61 