### PR TITLE
chore: remove obsolete version from dockerfile

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Add this file to extend the docker compose setup, e.g.:
 # docker compose -f docker-compose-prod.yml --env-file .env.prod up -d --build --force-recreate
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   wordcharts:
     build:


### PR DESCRIPTION
## Description
`version` is now obsolete in dockerfiles and should be removed.