### PR TITLE
chore: enable ARM64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "enable-arm64-build"]
   release:
     types: [published]
             
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.0
+          version: v0.30.1
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
@@ -68,7 +68,7 @@ jobs:
           push: true
           provenance: false
           target: production
-          #platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
This MR:
- updates docker buildx to 0.30.1 for testing
- enables the arm64 build